### PR TITLE
Fix STR_SCENARIO_START_ID to allow WC_II_custom_terrain modification

### DIFF
--- a/utils/strings/scenario.cfg
+++ b/utils/strings/scenario.cfg
@@ -16,7 +16,7 @@ _ "Allies" #enddef
 "wct_enemy" #enddef
 
 #define STR_SCENARIO_START_ID PLAYERS_NUMBER
-World_Conquest_II_{PLAYERS_NUMBER}p #enddef
+WC_II_{PLAYERS_NUMBER}p #enddef
 
 #define STR_P
 _ "players^p" #enddef


### PR DESCRIPTION
In `utils/custom_terrain_mod.cfg` there is a `allow_scenario= {STR_CAMPAIGN_WC_II_SCENARIOS_ID}`

However, the ID is defined as `World_Conquest_II_{PLAYERS_NUMBER}p` in `utils/strings/scenario.cfg`, 
where it should be `WC_II_{PLAYERS}p` in `scenarios/WC_II_scenario.cfg`